### PR TITLE
Test for a model belongs to 2 remote models and uses correct keys

### DIFF
--- a/lib/remote_association.rb
+++ b/lib/remote_association.rb
@@ -40,16 +40,18 @@ module RemoteAssociation
       #
       # Author.add_activeresource_relation(:profile, {class_name: "Profile", foreign_key: "author_id"})
       def add_activeresource_relation(name, options)
-        existing_relations = activeresource_relations
-        existing_relations[name] = options
-        @activeresource_relations = existing_relations
+        activeresource_relations[name] = options
       end
 
       # Returns settings for relations to ActiveResource models.
       #
       # === Examples
       #
-      # Author.activeresource_relations #=> [{profile: {class_name: "Profile", foreign_key: "author_id"}}]
+      # Author.activeresource_relations #=>
+      #   {
+      #     profile: {class_name: "Profile", foreign_key: "author_id"},
+      #     badges: {class_name: "Badge", foreign_key: "author_id"}
+      #   }
       def activeresource_relations
         @activeresource_relations ||= {}
       end

--- a/lib/remote_association/active_record/relation.rb
+++ b/lib/remote_association/active_record/relation.rb
@@ -37,7 +37,7 @@ module ActiveRecord
     def fetch_and_join_for_has_one_remote(ar_accessor, foreign_key, ar_class)
       keys = self.uniq.pluck(:id)
 
-      remote_objects = fetch_remote_objects(ar_class, keys)
+      remote_objects = fetch_remote_objects(ar_class, ar_accessor, keys)
 
       self.each do |u|
         u.send("#{ar_accessor}=", remote_objects.select { |s| s.send(foreign_key) == u.id })
@@ -47,7 +47,7 @@ module ActiveRecord
     def fetch_and_join_for_has_many_remote(ar_accessor, foreign_key, ar_class)
       keys = self.uniq.pluck(:id)
 
-      remote_objects = fetch_remote_objects(ar_class, keys)
+      remote_objects = fetch_remote_objects(ar_class, ar_accessor, keys)
 
       self.each do |r|
         r.send("#{ar_accessor}=", remote_objects.select { |s| s.send(foreign_key) == r.id })
@@ -59,7 +59,7 @@ module ActiveRecord
 
       return if keys.empty?
 
-      remote_objects = fetch_remote_objects(ar_class, keys)
+      remote_objects = fetch_remote_objects(ar_class, ar_accessor, keys)
 
       self.each do |u|
         u.send("#{ar_accessor}=", remote_objects.select { |s| u.send(foreign_key) == s.id })
@@ -72,9 +72,8 @@ module ActiveRecord
       end
     end
 
-    def fetch_remote_objects(ar_class, keys)
-      ar_class.find(:all, :params => klass.build_params_hash(keys))
+    def fetch_remote_objects(ar_class, ar_accessor, keys)
+      ar_class.find(:all, :params => klass.send(:"build_params_hash_for_#{ar_accessor}", keys))
     end
-
   end
 end

--- a/lib/remote_association/belongs_to_remote.rb
+++ b/lib/remote_association/belongs_to_remote.rb
@@ -61,19 +61,18 @@ module RemoteAssociation
             if remote_resources_prefetched?
               @#{remote_rel} ? @#{remote_rel}.first : nil
             else
-              @#{remote_rel} ||= self.#{rel_options[:foreign_key]}.present? ? #{rel_options[:class_name]}.find(:first, params: self.class.build_params_hash(self.#{rel_options[:foreign_key]})) : nil
+              @#{remote_rel} ||= self.#{rel_options[:foreign_key]}.present? ? #{rel_options[:class_name]}.find(:first, params: self.class.build_params_hash_for_#{remote_rel}(self.#{rel_options[:foreign_key]})) : nil
             end
           end
 
           ##
           # Returns Hash with HTTP parameters to query remote API
-          def self.build_params_hash(keys)
+          def self.build_params_hash_for_#{remote_rel}(keys)
             keys = [keys] unless keys.kind_of?(Array)
             {"#{rel_options[:primary_key]}" => keys}
           end
 
         RUBY
-
       end
   end
 end

--- a/lib/remote_association/has_many_remote.rb
+++ b/lib/remote_association/has_many_remote.rb
@@ -50,18 +50,40 @@ module RemoteAssociation
 
         attr_accessor :#{remote_rel}
 
-        def #{remote_rel}                                                 #  def customers
-          if remote_resources_prefetched?                                 #    if remote_resources_prefetched?
-            @#{remote_rel} ? @#{remote_rel} : nil                         #      @customers ? @customers : nil
-          else                                                            #    else
-            @#{remote_rel} ||= #{rel_options[:class_name]}.               #      @customers ||= Person.
-              find(:all, params: self.class.build_params_hash(self.id))   #        find(:all, params: self.class.build_params_hash(self.id))
-          end                                                             #    end
-        end                                                               #  end
+        ##
+        # Adds a method to call remote relation
+        #
+        # === Example
+        #
+        #  def customers
+        #    if remote_resources_prefetched?
+        #      @customers ? @customers : nil
+        #    else
+        #      @customers ||= Person.
+        #        find(:all, params: self.class.build_params_hash_for_customers(self.id))
+        #    end
+        #  end
+        #
+        def #{remote_rel}
+          if remote_resources_prefetched?
+            @#{remote_rel} ? @#{remote_rel} : nil
+          else
+            @#{remote_rel} ||= #{rel_options[:class_name]}.
+              find(:all, params: self.class.build_params_hash_for_#{remote_rel}(self.id))
+          end
+        end
 
         ##
         # Returns Hash with HTTP parameters to query remote API
-        def self.build_params_hash(keys)
+        #
+        # == Example
+        #
+        #  def self.build_params_hash_for_customer(keys)
+        #    keys = [keys] unless keys.kind_of?(Array)
+        #    {"user_id" => keys}
+        #  end
+        #
+        def self.build_params_hash_for_#{remote_rel}(keys)
           keys = [keys] unless keys.kind_of?(Array)
           {"#{rel_options[:foreign_key]}" => keys}
         end

--- a/lib/remote_association/has_one_remote.rb
+++ b/lib/remote_association/has_one_remote.rb
@@ -54,13 +54,13 @@ module RemoteAssociation
             if remote_resources_prefetched?
               @#{remote_rel} ? @#{remote_rel}.first : nil
             else
-              @#{remote_rel} ||= #{rel_options[:class_name]}.find(:first, params: self.class.build_params_hash(self.id))
+              @#{remote_rel} ||= #{rel_options[:class_name]}.find(:first, params: self.class.build_params_hash_for_#{remote_rel}(self.id))
             end
           end
 
           ##
           # Returns Hash with HTTP parameters to query remote API
-          def self.build_params_hash(keys)
+          def self.build_params_hash_for_#{remote_rel}(keys)
             keys = [keys] unless keys.kind_of?(Array)
             {"#{rel_options[:foreign_key]}" => keys}
           end

--- a/spec/remote_association/belongs_to_remote_spec.rb
+++ b/spec/remote_association/belongs_to_remote_spec.rb
@@ -138,6 +138,7 @@ describe RemoteAssociation, "method :belongs_to_remote" do
     end
 
     it "returns remotes respectively by foreign key and classname" do
+      User.delete_all
       add_user(1, 'Tester')
       User.first.foos.collect {|f| [f.id, f.stuff] }.should =~ [[1, 'F1']]
       User.first.bars.collect {|b| [b.id, b.oid] }.should =~ [[1, 'B1'], [3, 'B2'], [3, 'B3']]

--- a/spec/remote_association/belongs_to_remote_spec.rb
+++ b/spec/remote_association/belongs_to_remote_spec.rb
@@ -108,8 +108,11 @@ describe RemoteAssociation, "method :belongs_to_remote" do
       unset_const(:User)
       class User < ActiveRecord::Base
         include RemoteAssociation::Base
-        has_many_remote :foos, foreign_key: 'zoid', class_name: "CustomFoo"
-        has_many_remote :bars, foreign_key: 'pie', class_name: "CustomBar"
+        belongs_to_remote :foos, foreign_key: 'user_side_zoid_id', class_name: "CustomFoo", primary_key: 'zoid_id'
+        belongs_to_remote :bars, foreign_key: 'user_side_pie_id', class_name: "CustomBar", primary_key: 'pie_id'
+
+        def user_side_zoid_id; self.id; end
+        def user_side_pie_id; self.id; end
       end
       class CustomFoo < ActiveResource::Base
         self.site = REMOTE_HOST
@@ -121,17 +124,17 @@ describe RemoteAssociation, "method :belongs_to_remote" do
       end
 
       @foos_body = [
-          {foo: {id: 1, stuff: "F1"}},
+          {foo: {id: 1, zoid_id: 1, stuff: "F1"}},
       ].to_json
 
       @bars_body = [
-          {bar: {id: 1, oid: "B1"}},
-          {bar: {id: 2, oid: "B2"}},
-          {bar: {id: 3, oid: "B3"}},
+          {bar: {id: 1, pie_id: 1, oid: "B1"}},
+          {bar: {id: 2, pie_id: 1, oid: "B2"}},
+          {bar: {id: 3, pie_id: 1, oid: "B3"}},
       ].to_json
 
-      FakeWeb.register_uri(:get, "#{REMOTE_HOST}/foos.json?zoid%5B%5D=1", body: @foos_body)
-      FakeWeb.register_uri(:get, "#{REMOTE_HOST}/bars.json?pie%5B%5D=1", body: @bars_body)
+      FakeWeb.register_uri(:get, "#{REMOTE_HOST}/foos.json?zoid_id%5B%5D=1", body: @foos_body)
+      FakeWeb.register_uri(:get, "#{REMOTE_HOST}/bars.json?pie_id%5B%5D=1", body: @bars_body)
     end
 
     it "returns remotes respectively by foreign key and classname" do

--- a/spec/remote_association/belongs_to_remote_spec.rb
+++ b/spec/remote_association/belongs_to_remote_spec.rb
@@ -137,11 +137,11 @@ describe RemoteAssociation, "method :belongs_to_remote" do
       FakeWeb.register_uri(:get, "#{REMOTE_HOST}/bars.json?pie_id%5B%5D=1", body: @bars_body)
     end
 
-    it "returns remotes respectively by foreign key and classname" do
+    it "returns remotes respectively by primary and classname" do
       User.delete_all
       add_user(1, 'Tester')
       User.first.foos.collect {|f| [f.id, f.stuff] }.should =~ [[1, 'F1']]
-      User.first.bars.collect {|b| [b.id, b.oid] }.should =~ [[1, 'B1'], [3, 'B2'], [3, 'B3']]
+      User.first.bars.collect {|b| [b.id, b.oid] }.should =~ [[1, 'B1'], [2, 'B2'], [3, 'B3']]
     end
   end
 end

--- a/spec/remote_association/belongs_to_remote_spec.rb
+++ b/spec/remote_association/belongs_to_remote_spec.rb
@@ -108,11 +108,11 @@ describe RemoteAssociation, "method :belongs_to_remote" do
       unset_const(:User)
       class User < ActiveRecord::Base
         include RemoteAssociation::Base
-        belongs_to_remote :foos, foreign_key: 'user_side_zoid_id', class_name: "CustomFoo", primary_key: 'zoid_id'
-        belongs_to_remote :bars, foreign_key: 'user_side_pie_id', class_name: "CustomBar", primary_key: 'pie_id'
+        belongs_to_remote :foos, foreign_key: 'user_side_foo_id', class_name: "CustomFoo", primary_key: 'foo_id'
+        belongs_to_remote :bars, foreign_key: 'user_side_bar_id', class_name: "CustomBar", primary_key: 'bar_id'
 
-        def user_side_zoid_id; self.id; end
-        def user_side_pie_id; self.id; end
+        def user_side_foo_id; self.id; end
+        def user_side_bar_id; self.id; end
       end
       class CustomFoo < ActiveResource::Base
         self.site = REMOTE_HOST
@@ -124,24 +124,24 @@ describe RemoteAssociation, "method :belongs_to_remote" do
       end
 
       @foos_body = [
-          {foo: {id: 1, zoid_id: 1, stuff: "F1"}},
+          {foo: {id: 1, foo_id: 1, value: "F1"}},
       ].to_json
 
       @bars_body = [
-          {bar: {id: 1, pie_id: 1, oid: "B1"}},
-          {bar: {id: 2, pie_id: 1, oid: "B2"}},
-          {bar: {id: 3, pie_id: 1, oid: "B3"}},
+          {bar: {id: 1, bar_id: 1, value: "B1"}},
+          {bar: {id: 2, bar_id: 1, value: "B2"}},
+          {bar: {id: 3, bar_id: 1, value: "B3"}},
       ].to_json
 
-      FakeWeb.register_uri(:get, "#{REMOTE_HOST}/foos.json?zoid_id%5B%5D=1", body: @foos_body)
-      FakeWeb.register_uri(:get, "#{REMOTE_HOST}/bars.json?pie_id%5B%5D=1", body: @bars_body)
+      FakeWeb.register_uri(:get, "#{REMOTE_HOST}/foos.json?foo_id%5B%5D=1", body: @foos_body)
+      FakeWeb.register_uri(:get, "#{REMOTE_HOST}/bars.json?bar_id%5B%5D=1", body: @bars_body)
     end
 
     it "returns remotes respectively by primary and classname" do
       User.delete_all
       add_user(1, 'Tester')
-      User.first.foos.collect {|f| [f.id, f.stuff] }.should =~ [[1, 'F1']]
-      User.first.bars.collect {|b| [b.id, b.oid] }.should =~ [[1, 'B1'], [2, 'B2'], [3, 'B3']]
+      User.first.foos.collect {|f| [f.id, f.value] }.should =~ [[1, 'F1']]
+      User.first.bars.collect {|b| [b.id, b.value] }.should =~ [[1, 'B1'], [2, 'B2'], [3, 'B3']]
     end
   end
 end

--- a/spec/remote_association/belongs_to_remote_spec.rb
+++ b/spec/remote_association/belongs_to_remote_spec.rb
@@ -102,4 +102,42 @@ describe RemoteAssociation, "method :belongs_to_remote" do
       Profile.first.user.name.should eq('User A')
     end
   end
+
+  context "safe when using several remotes" do
+    before do
+      unset_const(:User)
+      class User < ActiveRecord::Base
+        include RemoteAssociation::Base
+        has_many_remote :foos, foreign_key: 'zoid', class_name: "CustomFoo"
+        has_many_remote :bars, foreign_key: 'pie', class_name: "CustomBar"
+      end
+      class CustomFoo < ActiveResource::Base
+        self.site = REMOTE_HOST
+        self.element_name = "foo"
+      end
+      class CustomBar < ActiveResource::Base
+        self.site = REMOTE_HOST
+        self.element_name = "bar"
+      end
+
+      @foos_body = [
+          {foo: {id: 1, stuff: "F1"}},
+      ].to_json
+
+      @bars_body = [
+          {bar: {id: 1, oid: "B1"}},
+          {bar: {id: 2, oid: "B2"}},
+          {bar: {id: 3, oid: "B3"}},
+      ].to_json
+
+      FakeWeb.register_uri(:get, "#{REMOTE_HOST}/foos.json?zoid%5B%5D=1", body: @foos_body)
+      FakeWeb.register_uri(:get, "#{REMOTE_HOST}/bars.json?pie%5B%5D=1", body: @bars_body)
+    end
+
+    it "returns remotes respectively by foreign key and classname" do
+      add_user(1, 'Tester')
+      User.first.foos.collect {|f| [f.id, f.stuff] }.should =~ [[1, 'F1']]
+      User.first.bars.collect {|b| [b.id, b.oid] }.should =~ [[1, 'B1'], [3, 'B2'], [3, 'B3']]
+    end
+  end
 end

--- a/spec/remote_association/has_many_remote_spec.rb
+++ b/spec/remote_association/has_many_remote_spec.rb
@@ -82,8 +82,8 @@ describe RemoteAssociation, 'method :has_many_remote' do
       unset_const(:User)
       class User < ActiveRecord::Base
         include RemoteAssociation::Base
-        has_many_remote :foos, foreign_key: 'zoid_id', class_name: "CustomFoo"
-        has_many_remote :bars, foreign_key: 'pie_id', class_name: "CustomBar"
+        has_many_remote :foos, foreign_key: 'foo_id', class_name: "CustomFoo"
+        has_many_remote :bars, foreign_key: 'bar_id', class_name: "CustomBar"
       end
       class CustomFoo < ActiveResource::Base
         self.site = REMOTE_HOST
@@ -95,24 +95,24 @@ describe RemoteAssociation, 'method :has_many_remote' do
       end
 
       @foos_body = [
-          {foo: {id: 1, zoid_id: 1, stuff: "F1"}},
+          {foo: {id: 1, foo_id: 1, value: "F1"}},
       ].to_json
 
       @bars_body = [
-          {bar: {id: 1, pie_id: 1, oid: "B1"}},
-          {bar: {id: 2, pie_id: 1, oid: "B2"}},
-          {bar: {id: 3, pie_id: 1, oid: "B3"}},
+          {bar: {id: 1, bar_id: 1, value: "B1"}},
+          {bar: {id: 2, bar_id: 1, value: "B2"}},
+          {bar: {id: 3, bar_id: 1, value: "B3"}},
       ].to_json
 
-      FakeWeb.register_uri(:get, "#{REMOTE_HOST}/foos.json?zoid_id%5B%5D=1", body: @foos_body)
-      FakeWeb.register_uri(:get, "#{REMOTE_HOST}/bars.json?pie_id%5B%5D=1", body: @bars_body)
+      FakeWeb.register_uri(:get, "#{REMOTE_HOST}/foos.json?foo_id%5B%5D=1", body: @foos_body)
+      FakeWeb.register_uri(:get, "#{REMOTE_HOST}/bars.json?bar_id%5B%5D=1", body: @bars_body)
     end
 
     it "returns remotes respectively by foreign key and classname" do
       User.delete_all
       add_user(1, 'Tester')
-      User.first.foos.collect {|f| [f.id, f.stuff] }.should =~ [[1, 'F1']]
-      User.first.bars.collect {|b| [b.id, b.oid] }.should =~ [[1, 'B1'], [2, 'B2'], [3, 'B3']]
+      User.first.foos.collect {|f| [f.id, f.value] }.should =~ [[1, 'F1']]
+      User.first.bars.collect {|b| [b.id, b.value] }.should =~ [[1, 'B1'], [2, 'B2'], [3, 'B3']]
     end
   end
 end

--- a/spec/remote_association/has_many_remote_spec.rb
+++ b/spec/remote_association/has_many_remote_spec.rb
@@ -41,10 +41,10 @@ describe RemoteAssociation, 'method :has_many_remote' do
     users.last.profiles.map(&:like).should eq ["letter C"]
   end
 
-  describe '#build_params_hash' do
+  describe '#build_params_hash_for_relation' do
     it 'returns valid Hash of HTTP query string parameters' do
-      User.build_params_hash(10).should eq({'user_id' => [10]})
-      User.build_params_hash([10, 13, 15]).should eq({'user_id' => [10, 13, 15]})
+      User.build_params_hash_for_profiles(10).should eq({'user_id' => [10]})
+      User.build_params_hash_for_profiles([10, 13, 15]).should eq({'user_id' => [10, 13, 15]})
     end
   end
 
@@ -111,6 +111,7 @@ describe RemoteAssociation, 'method :has_many_remote' do
     it "returns remotes respectively by foreign key and classname" do
       User.delete_all
       add_user(1, 'Tester')
+
       User.first.foos.collect {|f| [f.id, f.value] }.should =~ [[1, 'F1']]
       User.first.bars.collect {|b| [b.id, b.value] }.should =~ [[1, 'B1'], [2, 'B2'], [3, 'B3']]
     end

--- a/spec/remote_association/has_one_remote_spec.rb
+++ b/spec/remote_association/has_one_remote_spec.rb
@@ -38,10 +38,10 @@ describe RemoteAssociation, "method :has_one_remote" do
     users.last.profile.like.should eq('letter B')
   end
 
-  describe "#build_params_hash" do
+  describe "#build_params_hash_for_relation" do
     it "returns valid Hash of HTTP query string parameters" do
-      User.build_params_hash(10).should eq({'user_id' => [10]})
-      User.build_params_hash([10, 13, 15]).should eq({'user_id' => [10, 13, 15]})
+      User.build_params_hash_for_profile(10).should eq({'user_id' => [10]})
+      User.build_params_hash_for_profile([10, 13, 15]).should eq({'user_id' => [10, 13, 15]})
     end
   end
 


### PR DESCRIPTION
Test for a model belongs to 2 remote models and uses correct foreign_keys and primary_keys

1) 

when User

``` ruby
        belongs_to_remote :foos, foreign_key: 'user_side_zoid_id', class_name: "CustomFoo", primary_key: 'zoid_id'
        belongs_to_remote :bars, foreign_key: 'user_side_pie_id', class_name: "CustomBar", primary_key: 'pie_id'

        def user_side_zoid_id; self.id; end
        def user_side_pie_id; self.id; end
```

then second association tries to use keys from first, see URL

```
  1) RemoteAssociation method :belongs_to_remote safe when using several remotes returns remotes respectively by primary and classname
     Failure/Error: User.first.foos.collect {|f| [f.id, f.stuff] }.should =~ [[1, 'F1']]
     FakeWeb::NetConnectNotAllowedError:
       Real HTTP connections are disabled. Unregistered request: GET http://127.0.0.1:3000/foos.json?pie_id%5B%5D=1
     # ./lib/remote_association/belongs_to_remote.rb:64:in `foos'
     # ./spec/remote_association/belongs_to_remote_spec.rb:143:in `block (3 levels) in <top (required)>'
```

2)

when User

``` ruby
        has_many_remote :foos, foreign_key: 'zoid_id', class_name: "CustomFoo"
        has_many_remote :bars, foreign_key: 'pie_id', class_name: "CustomBar"
```

then second association tries to use keys from first, see URL

```
  2) RemoteAssociation method :has_many_remote safe when using several remotes returns remotes respectively by foreign key and classname
     Failure/Error: User.first.foos.collect {|f| [f.id, f.stuff] }.should =~ [[1, 'F1']]
     FakeWeb::NetConnectNotAllowedError:
       Real HTTP connections are disabled. Unregistered request: GET http://127.0.0.1:3000/foos.json?pie_id%5B%5D=1
     # ./lib/remote_association/has_many_remote.rb:57:in `foos'
     # ./spec/remote_association/has_many_remote_spec.rb:114:in `block (3 levels) in <top (required)>'
```
