### PR TITLE
Fix ActiveResource undefined method `first' for nil if resource unavailable in belongs_to_remote

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    remote_association (0.0.4)
+    remote_association (0.0.5)
       activerecord (~> 3.2)
       activeresource (~> 3.2)
       activesupport (~> 3.2)
@@ -9,27 +9,27 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (3.2.8)
-      activesupport (= 3.2.8)
+    activemodel (3.2.19)
+      activesupport (= 3.2.19)
       builder (~> 3.0.0)
-    activerecord (3.2.8)
-      activemodel (= 3.2.8)
-      activesupport (= 3.2.8)
+    activerecord (3.2.19)
+      activemodel (= 3.2.19)
+      activesupport (= 3.2.19)
       arel (~> 3.0.2)
       tzinfo (~> 0.3.29)
-    activeresource (3.2.8)
-      activemodel (= 3.2.8)
-      activesupport (= 3.2.8)
-    activesupport (3.2.8)
-      i18n (~> 0.6)
+    activeresource (3.2.19)
+      activemodel (= 3.2.19)
+      activesupport (= 3.2.19)
+    activesupport (3.2.19)
+      i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
-    arel (3.0.2)
-    builder (3.0.3)
+    arel (3.0.3)
+    builder (3.0.4)
     database_cleaner (0.8.0)
     diff-lcs (1.1.3)
     fakeweb (1.3.0)
-    i18n (0.6.1)
-    multi_json (1.3.6)
+    i18n (0.6.11)
+    multi_json (1.10.1)
     pg (0.14.1)
     rake (0.9.2.2)
     rspec (2.11.0)
@@ -40,7 +40,7 @@ GEM
     rspec-expectations (2.11.3)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.3)
-    tzinfo (0.3.33)
+    tzinfo (0.3.42)
 
 PLATFORMS
   ruby

--- a/lib/remote_association/belongs_to_remote.rb
+++ b/lib/remote_association/belongs_to_remote.rb
@@ -71,7 +71,7 @@ module RemoteAssociation
                 @#{remote_rel} ? @#{remote_rel}.first : nil
               else
                 @#{remote_rel} ||= if self.#{rel_options[:foreign_key]}.present? && self.#{rel_options[:foreign_class]}.present?
-                                     #{rel_options[:foreign_type]}.classify.constantize.find(:first, params: self.class.build_params_hash_for_#{remote_rel}(self.#{rel_options[:foreign_key]}))
+                                     #{rel_options[:foreign_type]}.classify.constantize.find(:all, params: self.class.build_params_hash_for_#{remote_rel}(self.#{rel_options[:foreign_key]})).try(:first)
                                    else
                                      nil
                                    end
@@ -96,7 +96,7 @@ module RemoteAssociation
                 @#{remote_rel} ? @#{remote_rel}.first : nil
               else
                 @#{remote_rel} ||= if self.#{rel_options[:foreign_key]}.present?
-                                     #{rel_options[:class_name]}.find(:first, params: self.class.build_params_hash_for_#{remote_rel}(self.#{rel_options[:foreign_key]}))
+                                     #{rel_options[:class_name]}.find(:all, params: self.class.build_params_hash_for_#{remote_rel}(self.#{rel_options[:foreign_key]})).try(:first)
                                    else
                                      nil
                                    end

--- a/lib/remote_association/version.rb
+++ b/lib/remote_association/version.rb
@@ -1,3 +1,3 @@
 module RemoteAssociation
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end

--- a/remote_association.gemspec
+++ b/remote_association.gemspec
@@ -25,5 +25,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'pg',                '~> 0.14'
   gem.add_development_dependency 'database_cleaner',  '~> 0.8'
   gem.add_development_dependency 'fakeweb'
-
 end

--- a/spec/remote_association/belongs_to_remote_spec.rb
+++ b/spec/remote_association/belongs_to_remote_spec.rb
@@ -148,6 +148,32 @@ describe RemoteAssociation, "method :belongs_to_remote" do
     end
   end
 
+  context "resource unavailable" do
+    subject { Profile.first.user }
+    before do
+      unset_const(:Profile)
+      class Profile < ActiveRecord::Base
+        include RemoteAssociation::Base
+        belongs_to_remote :user
+      end
+      FakeWeb.register_uri(:get, "#{REMOTE_HOST}/users.json?id%5B%5D=1", status: '404', body: '<html>
+<head><title>404 Not Found</title></head>
+<body bgcolor="white">
+<center><h1>404 Not Found</h1></center>
+<hr><center>nginx/1.6.2</center>
+</body>
+</html>')
+    end
+
+    it "not raises error" do
+      expect { subject }.to_not raise_error
+    end
+
+    it "is nil" do
+      should be_nil
+    end
+  end
+
   context "safe when using several remotes" do
     before do
       unset_const(:User)

--- a/spec/tasks/db_setup.rake
+++ b/spec/tasks/db_setup.rake
@@ -1,4 +1,5 @@
 require 'active_record'
+require 'yaml'
 
 namespace :spec do
   namespace :db do
@@ -75,6 +76,3 @@ SQL
     end
   end
 end
-
-
-


### PR DESCRIPTION
Related to https://github.com/denyago/remote_association/issues/6

Given: `Postcode` is `ActiveResource` model
When resource is unavailable next code raises undefined method `first' for nil:NilClass

``` ruby
Postcode.find(:first, params: {"search[code_in]"=>["AB1"]})
```

This code works fine:

``` ruby
Postcode.find(:all, params: {"search[code_in]"=>["AB1"]}).try(:first)
```
